### PR TITLE
Add admin panel with Firebase integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Админ-панель — Уютное Кафе</title>
+    <meta name="description" content="Управление категориями и товарами для сайта Уютное Кафе.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <script type="module" src="script.js"></script>
+  </head>
+  <body data-page="admin">
+    <div class="admin-page">
+      <section class="admin-auth" id="adminAuth">
+        <div class="admin-auth-card">
+          <div class="admin-auth-header">
+            <h1>Вход в админ-панель</h1>
+            <p>Используйте данные администратора, чтобы продолжить работу</p>
+          </div>
+          <form id="loginForm" class="admin-form" autocomplete="off">
+            <div class="admin-form-field">
+              <label for="login">Логин</label>
+              <input id="login" name="login" type="text" placeholder="Введите логин" required>
+            </div>
+            <div class="admin-form-field">
+              <label for="password">Пароль</label>
+              <input id="password" name="password" type="password" placeholder="Введите пароль" required>
+            </div>
+            <p class="admin-form-error" id="loginError" aria-live="polite"></p>
+            <button type="submit" class="button button-primary admin-submit">Войти</button>
+          </form>
+        </div>
+      </section>
+
+      <div class="admin-layout is-hidden" id="adminPanel">
+        <aside class="admin-sidebar">
+          <div class="admin-brand">
+            <span class="admin-brand-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 8h1.5a2.5 2.5 0 0 1 0 5H18"></path>
+                <path d="M2 8h16v6a6 6 0 0 1-6 6H8a6 6 0 0 1-6-6Z"></path>
+                <path d="M6 2v2"></path>
+                <path d="M10 2v2"></path>
+              </svg>
+            </span>
+            <div>
+              <strong>Уютное Кафе</strong>
+              <span>Панель управления</span>
+            </div>
+          </div>
+          <nav class="admin-nav">
+            <button type="button" class="admin-nav-button" data-section="categories">
+              <span>Категории</span>
+            </button>
+            <button type="button" class="admin-nav-button" data-section="products">
+              <span>Товары</span>
+            </button>
+            <button type="button" class="admin-nav-button" data-section="orders">
+              <span>Заказы</span>
+            </button>
+            <button type="button" class="admin-nav-button" data-section="reports">
+              <span>Отчёты</span>
+            </button>
+          </nav>
+        </aside>
+
+        <main class="admin-content">
+          <header class="admin-toolbar">
+            <h1>Администрирование</h1>
+            <p>Добавляйте категории и товары, чтобы обновлять меню кафе в режиме реального времени</p>
+          </header>
+
+          <div id="adminNotification" class="admin-notification" role="status" aria-live="polite"></div>
+
+          <section class="admin-section" data-section-content="categories">
+            <div class="admin-section-header">
+              <div>
+                <h2>Категории</h2>
+                <p>Создавайте новые категории меню с изображениями</p>
+              </div>
+            </div>
+            <form id="categoryForm" class="admin-form-card" autocomplete="off">
+              <div class="admin-form-grid">
+                <div class="admin-form-field">
+                  <label for="categoryName">Название категории</label>
+                  <input id="categoryName" name="categoryName" type="text" placeholder="Например, «Десерты»" required>
+                </div>
+                <div class="admin-form-field">
+                  <label for="categoryImage">Изображение категории</label>
+                  <input id="categoryImage" name="categoryImage" type="file" accept="image/*" required>
+                  <span class="admin-help-text">Загрузите изображение в формате JPG или PNG</span>
+                </div>
+              </div>
+              <button type="submit" class="button button-primary">Сохранить категорию</button>
+            </form>
+          </section>
+
+          <section class="admin-section is-hidden" data-section-content="products">
+            <div class="admin-section-header">
+              <div>
+                <h2>Товары</h2>
+                <p>Добавляйте блюда и напитки, которые будут отображаться на сайте</p>
+              </div>
+            </div>
+            <form id="productForm" class="admin-form-card" autocomplete="off">
+              <div class="admin-form-grid admin-form-grid--two">
+                <div class="admin-form-field">
+                  <label for="productId">ID товара</label>
+                  <input id="productId" name="productId" type="text" placeholder="Укажите уникальный ID" required>
+                </div>
+                <div class="admin-form-field">
+                  <label for="productCategory">Категория</label>
+                  <select id="productCategory" name="productCategory" required>
+                    <option value="" disabled selected>Выберите категорию</option>
+                  </select>
+                </div>
+                <div class="admin-form-field">
+                  <label for="productName">Название</label>
+                  <input id="productName" name="productName" type="text" placeholder="Например, «Капучино»" required>
+                </div>
+                <div class="admin-form-field">
+                  <label for="productPrice">Цена</label>
+                  <input id="productPrice" name="productPrice" type="number" min="0" step="0.01" placeholder="Цена в тенге" required>
+                </div>
+              </div>
+              <div class="admin-form-grid">
+                <div class="admin-form-field">
+                  <label for="productDescription">Описание</label>
+                  <textarea id="productDescription" name="productDescription" rows="4" placeholder="Краткое описание блюда"></textarea>
+                </div>
+                <div class="admin-form-field">
+                  <label for="productImage">Изображение товара</label>
+                  <input id="productImage" name="productImage" type="file" accept="image/*" required>
+                  <span class="admin-help-text">Загрузите изображение хорошего качества</span>
+                </div>
+              </div>
+              <button type="submit" class="button button-primary">Сохранить товар</button>
+            </form>
+          </section>
+
+          <section class="admin-section is-hidden" data-section-content="orders">
+            <div class="admin-placeholder">
+              <h2>Заказы</h2>
+              <p>Раздел находится в разработке. Скоро здесь появится управление заказами.</p>
+            </div>
+          </section>
+
+          <section class="admin-section is-hidden" data-section-content="reports">
+            <div class="admin-placeholder">
+              <h2>Отчёты</h2>
+              <p>Раздел находится в разработке. Здесь будут аналитика и отчёты.</p>
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+  </body>
+</html>

--- a/cart.html
+++ b/cart.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
-    <script src="script.js" defer></script>
+    <script type="module" src="script.js"></script>
   </head>
   <body data-page="cart">
     <header class="site-header">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
-    <script src="script.js" defer></script>
+    <script type="module" src="script.js"></script>
   </head>
   <body data-page="home">
     <header class="site-header">

--- a/style.css
+++ b/style.css
@@ -181,6 +181,10 @@ button {
   transform: scale(1);
 }
 
+.is-hidden {
+  display: none !important;
+}
+
 .hero {
   padding: 3rem 0 2rem;
 }
@@ -892,4 +896,310 @@ button {
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;
+}
+
+/* Admin page styles */
+
+body[data-page="admin"] {
+  background: hsl(var(--background));
+}
+
+.admin-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: stretch;
+  background: hsl(var(--background));
+}
+
+.admin-auth {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: clamp(2rem, 6vw, 4rem);
+}
+
+.admin-auth-card {
+  width: min(420px, 100%);
+  padding: clamp(2rem, 5vw, 3rem);
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.admin-auth-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+}
+
+.admin-auth-header p {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+}
+
+.admin-form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.admin-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-form-field label {
+  font-weight: 600;
+}
+
+.admin-form-field input,
+.admin-form-field select,
+.admin-form-field textarea {
+  font: inherit;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  transition: var(--transition-smooth);
+  resize: vertical;
+}
+
+.admin-form-field input:focus,
+.admin-form-field select:focus,
+.admin-form-field textarea:focus {
+  border-color: hsl(var(--coffee-medium));
+  outline: none;
+  box-shadow: 0 0 0 4px hsl(var(--coffee-medium) / 0.15);
+}
+
+.admin-form-field input[type="file"] {
+  padding: 0.5rem;
+}
+
+.admin-form-error {
+  min-height: 1.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+  color: hsl(var(--destructive));
+}
+
+.admin-submit {
+  justify-self: start;
+}
+
+.admin-layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  background: hsl(var(--background));
+}
+
+.admin-sidebar {
+  background: var(--gradient-coffee);
+  color: hsl(var(--primary-foreground));
+  padding: 2rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.admin-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.admin-brand strong {
+  display: block;
+  font-size: 1.1rem;
+}
+
+.admin-brand span {
+  display: block;
+  color: hsl(var(--primary-foreground) / 0.75);
+  font-size: 0.85rem;
+}
+
+.admin-brand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  background: hsl(var(--primary-foreground));
+  color: hsl(var(--coffee-dark));
+  box-shadow: var(--shadow-button);
+}
+
+.admin-brand-icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.admin-nav {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.admin-nav-button {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: hsl(var(--primary-foreground) / 0.1);
+  color: hsl(var(--primary-foreground));
+  font-weight: 600;
+  transition: var(--transition-smooth);
+  cursor: pointer;
+}
+
+.admin-nav-button:hover {
+  background: hsl(var(--primary-foreground) / 0.18);
+}
+
+.admin-nav-button.is-active {
+  border-color: hsl(var(--primary-foreground));
+  background: hsl(var(--primary-foreground));
+  color: hsl(var(--coffee-dark));
+  box-shadow: var(--shadow-button);
+}
+
+.admin-content {
+  padding: clamp(2rem, 5vw, 3.5rem);
+  display: grid;
+  gap: 2rem;
+}
+
+.admin-toolbar h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.admin-toolbar p {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+}
+
+.admin-notification {
+  position: sticky;
+  top: 1.5rem;
+  z-index: 5;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-md);
+  background: hsl(var(--coffee-medium));
+  color: hsl(var(--primary-foreground));
+  box-shadow: var(--shadow-soft);
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: var(--transition-smooth);
+  pointer-events: none;
+}
+
+.admin-notification.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.admin-notification[data-type='error'] {
+  background: hsl(var(--destructive));
+  color: hsl(var(--destructive-foreground));
+}
+
+.admin-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.admin-section-header h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+}
+
+.admin-section-header p {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+}
+
+.admin-form-card {
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.admin-form-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.admin-form-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.admin-help-text {
+  font-size: 0.85rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.admin-placeholder {
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+  border: 1px dashed hsl(var(--border));
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+  box-shadow: var(--shadow-card);
+}
+
+.admin-placeholder h2 {
+  margin: 0 0 0.5rem;
+  color: hsl(var(--foreground));
+}
+
+@media (max-width: 960px) {
+  .admin-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-sidebar {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .admin-nav {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(120px, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .admin-page {
+    flex-direction: column;
+  }
+
+  .admin-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-sidebar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-nav {
+    grid-auto-flow: row;
+  }
+
+  .admin-form-grid {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- create a new admin dashboard with authentication, category/product forms, and placeholders for orders and reports
- move Firebase initialization into the shared script, load categories/products from Firestore in real time, and upload images to Storage
- refresh styles for the admin experience and switch existing pages to module-based script loading while ignoring node_modules

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbe885210883288f15bc8f15890521