### PR TITLE
Adjust admin sidebar navigation styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1014,6 +1014,7 @@ body[data-page='admin'] {
 .admin-nav {
   display: grid;
   gap: 0.5rem;
+  margin-top: 1.25rem;
 }
 
 .admin-nav-button {
@@ -1021,21 +1022,21 @@ body[data-page='admin'] {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid #dddddd;
-  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.75);
   color: #333333;
   font-weight: 600;
   font-size: 0.9375rem;
   text-align: center;
   cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
 .admin-nav-button:hover {
   background: rgba(112, 0, 255, 0.08);
-  border-color: rgba(112, 0, 255, 0.35);
+  border-color: rgba(112, 0, 255, 0.25);
   color: var(--color-accent);
 }
 
@@ -1047,10 +1048,9 @@ body[data-page='admin'] {
 }
 
 .admin-nav-button.is-active {
-  background: rgba(112, 0, 255, 0.12);
+  background: var(--color-accent);
   border-color: var(--color-accent);
-  color: var(--color-accent);
-  box-shadow: 0 0 0 1px rgba(112, 0, 255, 0.18);
+  color: #ffffff;
 }
 
 .admin-menu-toggle {


### PR DESCRIPTION
## Summary
- add spacing between the admin sidebar brand block and navigation buttons
- tighten the admin navigation button padding for a more compact layout
- update the active admin navigation state to use the accent purple background

## Testing
- Not run


------
https://chatgpt.com/codex/tasks/task_e_68dcfdec09208328be02c21c53c4b9a0