### PR TITLE
Add admin item management UI and fix cart clearing

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -102,6 +102,10 @@
               </div>
               <button type="submit" class="button button-primary">Сохранить категорию</button>
             </form>
+            <div class="admin-entity-list" id="categoryList" aria-live="polite"></div>
+            <div class="orders-empty" id="categoryEmpty" hidden>
+              <p>Категории пока не добавлены.</p>
+            </div>
           </section>
 
           <section class="admin-section is-hidden" data-section-content="products">
@@ -145,6 +149,10 @@
               </div>
               <button type="submit" class="button button-primary">Сохранить товар</button>
             </form>
+            <div class="admin-entity-list" id="productList" aria-live="polite"></div>
+            <div class="orders-empty" id="productEmpty" hidden>
+              <p>Товары пока не добавлены.</p>
+            </div>
           </section>
 
           <section class="admin-section is-hidden" data-section-content="orders">

--- a/style.css
+++ b/style.css
@@ -542,6 +542,18 @@ button {
   transform: translateY(-2px);
 }
 
+.button-danger {
+  background: hsl(var(--destructive));
+  color: hsl(var(--destructive-foreground));
+  border-color: transparent;
+  box-shadow: var(--shadow-button);
+}
+
+.button-danger:hover {
+  transform: translateY(-2px) scale(1.01);
+  background: hsl(var(--destructive) / 0.9);
+}
+
 .button-icon svg {
   width: 18px;
   height: 18px;
@@ -1336,6 +1348,81 @@ body.admin-sidebar-open {
 .admin-orders {
   display: grid;
   gap: 1.25rem;
+}
+
+.admin-entity-list {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 0.5rem;
+}
+
+.admin-entity-card {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  box-shadow: var(--shadow-card);
+  align-items: center;
+}
+
+.admin-entity-card--category .admin-entity-media {
+  width: 100px;
+  height: 100px;
+}
+
+.admin-entity-media {
+  width: 120px;
+  height: 120px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: hsl(var(--muted));
+  flex-shrink: 0;
+}
+
+.admin-entity-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.admin-entity-body {
+  flex: 1;
+  min-width: 220px;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.admin-entity-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.admin-entity-title h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.admin-entity-price {
+  font-weight: 600;
+  color: hsl(var(--coffee-medium));
+}
+
+.admin-entity-category {
+  margin: 0;
+  font-size: 0.9rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.admin-entity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
 }
 
 .admin-placeholder {


### PR DESCRIPTION
## Summary
- add live category and product listings in the admin panel with edit and delete actions wired to Firestore
- allow reusing the admin forms to update existing entries, including keeping images and validating input, while styling the new lists
- correct the cart page so removing every item fully clears the view and shows the empty state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de42adca5883289e2cc945f9b801c4